### PR TITLE
setup for knitting manuscript to pdf within docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM rocker/r-ver:4.4.0
 
 # install OS binaries required by R packages - via rocker-versioned2/scripts/install_tidyverse.sh
+# additionally, stuff for rendering tex
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends \
     libxml2-dev \
@@ -21,7 +22,8 @@ RUN apt-get install -y --no-install-recommends \
     libjpeg-dev \
     unixodbc-dev \
     cmake \
-    awscli
+    awscli \
+    texlive-full
 
 
 # install required R packages using renv

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ docker run -it \
     flusionmanu Rscript code/compute_scores_joint_training.R
 ```
 
+The following knits the manuscript pdf (note that any updates to the pdf are persisted outside of the container):
+```bash
+docker run -it \
+    -v ./artifacts:/flusion-manuscript/artifacts \
+    -v ./manuscript:/flusion-manuscript/manuscript \
+    -w /flusion-manuscript/manuscript \
+    flusionmanu R -e "knitr::knit2pdf('flusion-manuscript.Rnw')"
+```
+
+
 ### Using `renv` without Docker
 
 We have not had good luck with using `renv` to get a stable development environment setup going across different machines, so we recommend using Docker as described above.  But if you want to try your luck, you can try to run the following command in an R session in this project:

--- a/renv.lock
+++ b/renv.lock
@@ -1,10 +1,10 @@
 {
   "R": {
-    "Version": "4.3.3",
+    "Version": "4.4.0",
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "https://cloud.r-project.org"
+        "URL": "https://p3m.dev/cran/2024-06-13"
       }
     ]
   },
@@ -1483,6 +1483,16 @@
         "withr"
       ],
       "Hash": "829f27b9c4919c16b593794a6344d6c0"
+    },
+    "tinytex": {
+      "Package": "tinytex",
+      "Version": "0.51",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "xfun"
+      ],
+      "Hash": "d44e2fcd2e4e076f0aac540208559d1d"
     },
     "tzdb": {
       "Package": "tzdb",


### PR DESCRIPTION
Updates to renv lockfile and Dockerfile to allow knitting the manuscript file from Rnw to pdf within the docker container.  The reviewer should be able to rebuild the docker image and run the command in the readme to render the document as a pdf.  You'll see some warnings about undefined section references (the document is still in progress) and will likely see some changes to the pdf relative to the version that's committed in the repo.